### PR TITLE
Adding notification forwarding in HTTP POST action

### DIFF
--- a/orchestrator/translator.js
+++ b/orchestrator/translator.js
@@ -174,7 +174,8 @@ var perseoRuleTemplate = {
   'action' : {
     'type' : '',
     'template' : '',
-    'parameters' : {}
+    'parameters' : {},
+    'mirror' : false
   }
 }
 
@@ -704,13 +705,22 @@ function transformToPerseoRequest(request) {
     case PerseoTypes.ActionType.POST : {
       // Translate body
       let postBodyVar = request.action.template;
-      let postBody = request.internalVariables[postBodyVar];
-      let resolvedVariables = resolveVariables(postBody);
-      perseoRule.action.parameters = request.action.parameters;
-      perseoRule.action.template = resolvedVariables.translatedTemplate;
-      for (let i = 0; i < resolvedVariables.inputVariables.length; i++){
-        addUniqueToArray(request.variables, resolvedVariables.inputVariables[i]);
+      let resolvedVariables;
+
+      if (postBodyVar === 'payload') {
+        perseoRule.action.mirror = true;
+        perseoRule.action.template = 'dummy-template';
+      } else {
+        perseoRule.action.mirror = false;
+        let postBody = request.internalVariables[postBodyVar];
+        let resolvedVariables = resolveVariables(postBody);
+        perseoRule.action.template = resolvedVariables.translatedTemplate;
+        for (let i = 0; i < resolvedVariables.inputVariables.length; i++){
+          addUniqueToArray(request.variables, resolvedVariables.inputVariables[i]);
+        }
       }
+
+      perseoRule.action.parameters = request.action.parameters;
 
       if (perseoRule.action.parameters.url == '{{url}}') {
         resolvedVariables = resolveVariables(request.internalVariables['url']);

--- a/test/orchestrator/translator-full-mesh-tests/6-post-flow.json
+++ b/test/orchestrator/translator-full-mesh-tests/6-post-flow.json
@@ -1,0 +1,81 @@
+[
+  {
+      "id": "2219ef6d.fba688",
+      "type": "device out",
+      "z": "456c7496.ac5c64",
+      "name": "",
+      "device": "",
+      "_device_id": "input-device-id",
+      "_device_label": "input-device-label",
+      "_device_type": "device",
+      "x": 290,
+      "y": 480,
+      "wires": [
+          [
+              "ab538af3.8d994"
+          ]
+      ]
+  },
+  {
+      "id": "ab538af3.8d994",
+      "type": "change",
+      "z": "456c7496.ac5c64",
+      "name": "",
+      "rules": [
+          {
+              "t": "set",
+              "p": "headers.h1",
+              "pt": "msg",
+              "to": "h1-value-change",
+              "tot": "str"
+          },
+          {
+              "t": "set",
+              "p": "headers.h2",
+              "pt": "msg",
+              "to": "h2-value-change",
+              "tot": "str"
+          },
+          {
+              "t": "set",
+              "p": "url",
+              "pt": "msg",
+              "to": "http://endpoint/device/{{payload.attr1}}",
+              "tot": "str"
+          },
+          {
+              "t": "set",
+              "p": "method",
+              "pt": "msg",
+              "to": "PUT",
+              "tot": "str"
+          }
+      ],
+      "action": "",
+      "property": "",
+      "from": "",
+      "to": "",
+      "reg": false,
+      "x": 717,
+      "y": 467.73333740234375,
+      "wires": [
+          [
+              "5db2b9d4.9aca68"
+          ]
+      ]
+  },
+  {
+      "id": "5db2b9d4.9aca68",
+      "type": "http request out",
+      "z": "456c7496.ac5c64",
+      "name": "",
+      "method": "use",
+      "ret": "txt",
+      "body": "payload",
+      "url": "",
+      "tls": "",
+      "x": 1049,
+      "y": 449.48333740234375,
+      "wires": []
+  }
+]

--- a/test/orchestrator/translator-full-mesh-tests/test.js
+++ b/test/orchestrator/translator-full-mesh-tests/test.js
@@ -54,7 +54,7 @@ function execute() {
                     "isPattern": false,
                     "type": "virtual"
                   },
-                  "template": "",
+                  "template": "", "mirror": false,
                   "type": "update"
                 },
                 "name": "rule_6a666fff_bfb128_1",
@@ -122,7 +122,7 @@ function execute() {
                     "isPattern": false,
                     "type": "virtual"
                   },
-                  "template": "",
+                  "template": "", "mirror": false,
                   "type": "update"
                 },
                 "name": "rule_6a666fff_bfb128_1",
@@ -167,7 +167,7 @@ function execute() {
                     "isPattern": false,
                     "type": "virtual"
                   },
-                  "template": "",
+                  "template": "", "mirror": false,
                   "type": "update"
                 },
                 "name": "rule_6a666fff_bfb128_2",
@@ -228,7 +228,7 @@ function execute() {
                     "isPattern": false,
                     "type": "virtual"
                   },
-                  "template": "",
+                  "template": "", "mirror": false,
                   "type": "update"
                 },
                 "name": "rule_6a666fff_bfb128_1",
@@ -324,7 +324,7 @@ function execute() {
                     "isPattern": false,
                     "type": "virtual"
                   },
-                  "template": "",
+                  "template": "", "mirror": false,
                   "type": "update"
                 },
                 "name": "rule_6a666fff_bfb128_1",
@@ -423,7 +423,7 @@ function execute() {
                     "isPattern": false,
                     "type": "virtual"
                   },
-                  "template": "",
+                  "template": "", "mirror": false,
                   "type": "update"
                 },
                 "name": "rule_6a666fff_bfb128_1",
@@ -489,7 +489,7 @@ function execute() {
                     "isPattern": false,
                     "type": "virtual"
                   },
-                  "template": "",
+                  "template": "", "mirror": false,
                   "type": "update"
                 },
                 "name": "rule_6a666fff_bfb128_1",
@@ -546,7 +546,7 @@ function execute() {
                     "subject": "You've got e-mail",
                     "to": "to@user.com"
                   },
-                  "template": "",
+                  "template": "", "mirror": false,
                   "type": "email"
                 },
                 "name": "rule_6a666fff_bfb128_1",
@@ -600,7 +600,7 @@ function execute() {
                     "subject": "You've got e-mail",
                     "to": "to@user.com"
                   },
-                  "template": "",
+                  "template": "", "mirror": false,
                   "type": "email"
                 },
                 "name": "rule_6a666fff_bfb128_1",
@@ -656,6 +656,7 @@ function execute() {
                     "url": "http://endpoint/device/attrs"
                   },
                   "template": "yes",
+                  "mirror": false,
                   "type" : "post"
                 },
                 "name": "rule_456c7496_ac5c64_1",
@@ -711,6 +712,7 @@ function execute() {
                     "url": "http://endpoint/device/attrs"
                   },
                   "template": "yes",
+                  "mirror": false,
                   "type" : "post"
                 },
                 "name": "rule_456c7496_ac5c64_1",
@@ -766,6 +768,7 @@ function execute() {
                     "url": "http://endpoint/device/${attr1}"
                   },
                   "template": "yes",
+                  "mirror": false,
                   "type" : "post"
                 },
                 "name": "rule_456c7496_ac5c64_1",
@@ -822,6 +825,7 @@ function execute() {
                     "url": "http://endpoint/device/${attr1}"
                   },
                   "template": "yes",
+                  "mirror": false,
                   "type" : "post"
                 },
                 "name": "rule_456c7496_ac5c64_1",
@@ -878,6 +882,7 @@ function execute() {
                     "url": "http://endpoint/device/${attr1}"
                   },
                   "template": "yes",
+                  "mirror": false,
                   "type" : "post"
                 },
                 "name": "rule_456c7496_ac5c64_1",
@@ -899,6 +904,62 @@ function execute() {
       });
     });
 
+
+    describe('Basic post flow with change node setting url and HTTP method externally in a change node', function() {
+      it('should generate all request correctly', function(done) {
+        var mashup = fs.readFile(__dirname+ '/6-post-flow.json', 'utf8', function(err, data) {
+          try {
+            let flow = JSON.parse(data);
+            let result = translator.translateMashup(flow);
+            let expected = {
+              "subscription": {
+                "description": "Subscription for input-device-id",
+                "notification": {
+                  "http": {
+                    "url": "http://perseo-fe:9090/noticesv2"
+                  }
+                },
+                "subject": {
+                  "entities": [
+                    {
+                      "id": "input-device-id",
+                      "type": "device"
+                    }
+                  ]
+                }
+              },
+              "perseoRequest": {
+                "action": {
+                  "parameters": {
+                    "headers": {
+                      "h1": "h1-value-change",
+                      "h2": "h2-value-change"
+                    },
+                    "method": "PUT",
+                    "url": "http://endpoint/device/${attr1}"
+                  },
+                  "template": "dummy-template",
+                  "mirror": true,
+                  "type" : "post"
+                },
+                "name": "rule_456c7496_ac5c64_1",
+                "text": "select *, \"rule_456c7496_ac5c64_1\" as ruleName, ev.attr1? as attr1 from pattern [every ev = iotEvent(cast(subscriptionId?, String) = \"12345\")]"
+              }
+            };
+            expect(result.length).equal(1);
+            expect(result[0].subscription).to.deep.equal(expected.subscription);
+
+            let perseoRequest = translator.generatePerseoRequest(12345, 0, result[0].originalRequest);
+            expect(perseoRequest).not.equal(undefined);
+            expect(perseoRequest).to.deep.equal(expected.perseoRequest);
+
+            done();
+          } catch (error) {
+            done(error);
+          }
+        });
+      });
+    });
 
 
 

--- a/test/orchestrator/translator-mashup-single-node/internal-test.js
+++ b/test/orchestrator/translator-mashup-single-node/internal-test.js
@@ -49,7 +49,7 @@ function execute() {
             },
             "action": {
               "type": "",
-              "template": "",
+              "template": "", "mirror": false,
               "parameters": {}
             },
             "inputDevice": {
@@ -74,7 +74,7 @@ function execute() {
               },
               "action": {
                 "type": "",
-                "template": "",
+                "template": "", "mirror": false,
                 "parameters": {}
               },
               "inputDevice": {
@@ -152,7 +152,7 @@ function execute() {
             },
             "action": {
               "type": "",
-              "template": "",
+              "template": "", "mirror": false,
               "parameters": {}
             },
             "inputDevice": {
@@ -177,7 +177,7 @@ function execute() {
               },
               "action": {
                 "type": "",
-                "template": "",
+                "template": "", "mirror": false,
                 "parameters": {}
               },
               "inputDevice": {
@@ -261,7 +261,7 @@ function execute() {
             },
             "action": {
               "type": "",
-              "template": "",
+              "template": "", "mirror": false,
               "parameters": {}
             },
             "inputDevice": {
@@ -286,7 +286,7 @@ function execute() {
               },
               "action": {
                 "type": "",
-                "template": "",
+                "template": "", "mirror": false,
                 "parameters": {}
               },
               "inputDevice": {
@@ -363,7 +363,7 @@ function execute() {
             },
             "action": {
               "type": "",
-              "template": "",
+              "template": "", "mirror": false,
               "parameters": {}
             },
             "inputDevice": {
@@ -388,7 +388,7 @@ function execute() {
               },
               "action": {
                 "type": "",
-                "template": "",
+                "template": "", "mirror": false,
                 "parameters": {}
               },
               "inputDevice": {
@@ -522,7 +522,7 @@ function execute() {
             },
             "action": {
               "type": "",
-              "template": "",
+              "template": "", "mirror": false,
               "parameters": {}
             },
             "inputDevice": {
@@ -547,7 +547,7 @@ function execute() {
               },
               "action": {
                 "type": "",
-                "template": "",
+                "template": "", "mirror": false,
                 "parameters": {}
               },
               "inputDevice": {
@@ -617,7 +617,7 @@ function execute() {
             },
             "action": {
               "type": "",
-              "template": "",
+              "template": "", "mirror": false,
               "parameters": {}
             },
             "inputDevice": {
@@ -642,7 +642,7 @@ function execute() {
               },
               "action": {
                 "type": "",
-                "template": "",
+                "template": "", "mirror": false,
                 "parameters": {}
               },
               "inputDevice": {
@@ -714,7 +714,7 @@ function execute() {
             },
             "action": {
               "type": "",
-              "template": "",
+              "template": "", "mirror": false,
               "parameters": {}
             },
             "inputDevice": {
@@ -740,7 +740,7 @@ function execute() {
               "action": {
                 "notificationEndpoint": "http://perseo-fe:9090/noticesv2",
                 "type": "",
-                "template": "",
+                "template": "", "mirror": false,
                 "parameters": {}
               },
               "inputDevice": {
@@ -815,7 +815,7 @@ function execute() {
             },
             "action": {
               "type": "",
-              "template": "",
+              "template": "", "mirror": false,
               "parameters": {}
             },
             "inputDevice": {
@@ -841,7 +841,7 @@ function execute() {
               "action": {
                 "notificationEndpoint": "http://perseo-fe:9090/noticesv2",
                 "type": "",
-                "template": "",
+                "template": "", "mirror": false,
                 "parameters": {}
               },
               "inputDevice": {

--- a/test/orchestrator/translator-mashup-single-node/test.js
+++ b/test/orchestrator/translator-mashup-single-node/test.js
@@ -49,7 +49,7 @@ function execute() {
             },
             "action": {
               "type": "",
-              "template": "",
+              "template": "", "mirror": false,
               "parameters": {}
             },
             "inputDevice": {
@@ -74,7 +74,7 @@ function execute() {
               },
               "action": {
                 "type": "",
-                "template": "",
+                "template": "", "mirror": false,
                 "parameters": {}
               },
               "inputDevice": {
@@ -152,7 +152,7 @@ function execute() {
             },
             "action": {
               "type": "",
-              "template": "",
+              "template": "", "mirror": false,
               "parameters": {}
             },
             "inputDevice": {
@@ -177,7 +177,7 @@ function execute() {
               },
               "action": {
                 "type": "",
-                "template": "",
+                "template": "", "mirror": false,
                 "parameters": {}
               },
               "inputDevice": {
@@ -261,7 +261,7 @@ function execute() {
             },
             "action": {
               "type": "",
-              "template": "",
+              "template": "", "mirror": false,
               "parameters": {}
             },
             "inputDevice": {
@@ -286,7 +286,7 @@ function execute() {
               },
               "action": {
                 "type": "",
-                "template": "",
+                "template": "", "mirror": false,
                 "parameters": {}
               },
               "inputDevice": {
@@ -363,7 +363,7 @@ function execute() {
             },
             "action": {
               "type": "",
-              "template": "",
+              "template": "", "mirror": false,
               "parameters": {}
             },
             "inputDevice": {
@@ -388,7 +388,7 @@ function execute() {
               },
               "action": {
                 "type": "",
-                "template": "",
+                "template": "", "mirror": false,
                 "parameters": {}
               },
               "inputDevice": {
@@ -522,7 +522,7 @@ function execute() {
             },
             "action": {
               "type": "",
-              "template": "",
+              "template": "", "mirror": false,
               "parameters": {}
             },
             "inputDevice": {
@@ -547,7 +547,7 @@ function execute() {
               },
               "action": {
                 "type": "",
-                "template": "",
+                "template": "", "mirror": false,
                 "parameters": {}
               },
               "inputDevice": {
@@ -617,7 +617,7 @@ function execute() {
             },
             "action": {
               "type": "",
-              "template": "",
+              "template": "", "mirror": false,
               "parameters": {}
             },
             "inputDevice": {
@@ -642,7 +642,7 @@ function execute() {
               },
               "action": {
                 "type": "",
-                "template": "",
+                "template": "", "mirror": false,
                 "parameters": {}
               },
               "inputDevice": {
@@ -713,7 +713,7 @@ function execute() {
             },
             "action": {
               "type": "",
-              "template": "",
+              "template": "", "mirror": false,
               "parameters": {}
             },
             "inputDevice": {
@@ -738,7 +738,7 @@ function execute() {
               },
               "action": {
                 "type": "",
-                "template": "",
+                "template": "", "mirror": false,
                 "parameters": {}
               },
               "inputDevice": {
@@ -815,7 +815,7 @@ function execute() {
             "action": {
               "notificationEndpoint": "http://perseo-fe:9090/noticesv2",
               "type": "",
-              "template": "",
+              "template": "", "mirror": false,
               "parameters": {}
             },
             "inputDevice": {
@@ -841,7 +841,7 @@ function execute() {
               "action": {
                 "notificationEndpoint": "http://perseo-fe:9090/noticesv2",
                 "type": "",
-                "template": "",
+                "template": "", "mirror": false,
                 "parameters": {}
               },
               "inputDevice": {

--- a/test/orchestrator/translator-orion-perseo-requests/test.js
+++ b/test/orchestrator/translator-orion-perseo-requests/test.js
@@ -32,7 +32,7 @@ function execute() {
               "action": {
                 "notificationEndpoint": "perseo-endpoint",
                 "type": "",
-                "template": "",
+                "template": "", "mirror": false,
                 "parameters": {}
               },
               "inputDevice": {
@@ -96,7 +96,7 @@ function execute() {
               "action": {
                 "notificationEndpoint": "perseo-endpoint",
                 "type": "",
-                "template": "",
+                "template": "", "mirror": false,
                 "parameters": {}
               },
               "inputDevice": {
@@ -166,7 +166,7 @@ function execute() {
               "action": {
                 "notificationEndpoint": "perseo-endpoint",
                 "type": "",
-                "template": "",
+                "template": "", "mirror": false,
                 "parameters": {}
               },
               "inputDevice": {
@@ -239,7 +239,7 @@ function execute() {
               "action": {
                 "notificationEndpoint": "perseo-endpoint",
                 "type": "",
-                "template": "",
+                "template": "", "mirror": false,
                 "parameters": {}
               },
               "inputDevice": {
@@ -314,7 +314,7 @@ function execute() {
               "action": {
                 "notificationEndpoint": "perseo-endpoint",
                 "type": "",
-                "template": "",
+                "template": "", "mirror": false,
                 "parameters": {}
               },
               "inputDevice": {
@@ -413,7 +413,7 @@ function execute() {
               "action": {
                 "notificationEndpoint": "perseo-endpoint",
                 "type": "",
-                "template": "",
+                "template": "", "mirror": false,
                 "parameters": {}
               },
               "inputDevice": {
@@ -517,7 +517,7 @@ function execute() {
               "action": {
                 "notificationEndpoint": "perseo-endpoint",
                 "type": "",
-                "template": "",
+                "template": "", "mirror": false,
                 "parameters": {}
               },
               "inputDevice": {
@@ -620,7 +620,7 @@ function execute() {
             "action": {
               "notificationEndpoint": "perseo-endpoint",
               "type": "update",
-              "template": "",
+              "template": "", "mirror": false,
               "parameters": {
                 "id" : "output-device-id",
                 "type" : "virtual",
@@ -647,7 +647,7 @@ function execute() {
                 "isPattern": false,
                 "type": "virtual",
               },
-              "template": "",
+              "template": "", "mirror": false,
               "type": "update",
             },
             "name": "simple-rule-1",
@@ -686,7 +686,7 @@ describe('Generate Perseo rule with UPDATE action', function() {
             "action": {
               "notificationEndpoint": "perseo-endpoint",
               "type": "update",
-              "template": "",
+              "template": "", "mirror": false,
               "parameters": {
                 "id" : "output-device-id",
                 "type" : "virtual",
@@ -713,7 +713,7 @@ describe('Generate Perseo rule with UPDATE action', function() {
                 "isPattern": false,
                 "type": "virtual",
               },
-              "template": "",
+              "template": "", "mirror": false,
               "type": "update",
             },
             "name": "simple-rule-1",
@@ -751,7 +751,7 @@ describe('Generate Perseo rule with UPDATE action', function() {
             "action": {
               "notificationEndpoint": "perseo-endpoint",
               "type": "email",
-              "template": "",
+              "template": "", "mirror": false,
               "parameters": {
                 "to" : "to@user.com",
                 "from" : "from@user.com",
@@ -775,7 +775,7 @@ describe('Generate Perseo rule with UPDATE action', function() {
                 "smtp" : "smtp@server.com",
                 "body" : "This is an email body with ${temperature}"
               },
-              "template": "",
+              "template": "", "mirror": false,
               "type": "email",
             },
             "name": "simple-rule-1",


### PR DESCRIPTION
This PR implements the notification forward in flows. 
When an user sets the 'Request body' in a http request node as "msg.payload", all attributes from the message will be forwarded to the configured destination.

This makes use of dojot/perseo-fe#5
