### PR TITLE
Fixing output value when a chained-event rule is used

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,9 +19,9 @@ RUN cd /usr/src/node-red/nodes/core; \
 # And add all dojot-related nodes
 COPY contrib-nodes /data/node_modules
 RUN useradd --home-dir /usr/src/node-red --no-create-home node-red \
+    && rm -fr /usr/src/node-red/node_modules \
     && chown -R node-red:node-red /data \
-    && chown -R node-red:node-red /usr/src/node-red \
-    && chown -R node-red:node-red /data/node_modules
+    && chown -R node-red:node-red /usr/src/node-red
 
 USER node-red
 RUN npm install && npm run build && cd /data && npm install

--- a/orchestrator/translator.js
+++ b/orchestrator/translator.js
@@ -677,7 +677,7 @@ function transformToPerseoRequest(request) {
   if (request.action.type == "") {
     return null;
   }
-  
+
   let perseoRule = cloneSimpleObject(perseoRuleTemplate);
 
   perseoRule.name = request.name;
@@ -774,8 +774,13 @@ function transformToPerseoRequest(request) {
 
   perseoRule.text = 'select *';
   perseoRule.text += ', \"' + request.name + '\" as ruleName';
+  let sourceEvent = 'ev';
+  if (request.pattern.secondEventConditions.length != 0) {
+    sourceEvent = 'ev2';
+  }
+
   for (let i = 0; i < request.variables.length; i++) {
-    perseoRule.text += ', ev.' + request.variables[i] + '? as ' + request.variables[i];
+    perseoRule.text += ', ' + sourceEvent + '.' + request.variables[i] + '? as ' + request.variables[i];
   }
 
   perseoRule.text += ' from pattern [';
@@ -784,7 +789,7 @@ function transformToPerseoRequest(request) {
     perseoRule.text += 'cast(subscriptionId?, String) = \"' + request.pattern.fixedEventSubscriptionId + '\"';
   } else if (request.pattern.firstEventSubscriptionId != '' && request.pattern.secondEventSubscriptionId != '') {
     perseoRule.text += 'cast(subscriptionId?, String) = \"' + request.pattern.firstEventSubscriptionId + '\")';
-    perseoRule.text += ' -> iotEvent(cast(subscriptionId?, String) = \"' + request.pattern.secondEventSubscriptionId + '\"';
+    perseoRule.text += ' -> ev2 = iotEvent(cast(subscriptionId?, String) = \"' + request.pattern.secondEventSubscriptionId + '\"';
   }
   perseoRule.text += ')]';
   return perseoRule;

--- a/test/orchestrator/translator-full-mesh-tests/test.js
+++ b/test/orchestrator/translator-full-mesh-tests/test.js
@@ -328,7 +328,7 @@ function execute() {
                   "type": "update"
                 },
                 "name": "rule_6a666fff_bfb128_1",
-                "text": "select *, \"rule_6a666fff_bfb128_1\" as ruleName, ev.attr1? as attr1 from pattern [every ev = iotEvent(cast(subscriptionId?, String) = \"12345\") -> iotEvent(cast(subscriptionId?, String) = \"123456\")]"
+                "text": "select *, \"rule_6a666fff_bfb128_1\" as ruleName, ev2.attr1? as attr1 from pattern [every ev = iotEvent(cast(subscriptionId?, String) = \"12345\") -> ev2 = iotEvent(cast(subscriptionId?, String) = \"123456\")]"
               }
             },
             ];
@@ -427,7 +427,7 @@ function execute() {
                   "type": "update"
                 },
                 "name": "rule_6a666fff_bfb128_1",
-                "text": "select *, \"rule_6a666fff_bfb128_1\" as ruleName, ev.attr1? as attr1, ev.attr2? as attr2 from pattern [every ev = iotEvent(cast(subscriptionId?, String) = \"12345\") -> iotEvent(cast(subscriptionId?, String) = \"123456\")]"
+                "text": "select *, \"rule_6a666fff_bfb128_1\" as ruleName, ev2.attr1? as attr1, ev2.attr2? as attr2 from pattern [every ev = iotEvent(cast(subscriptionId?, String) = \"12345\") -> ev2 = iotEvent(cast(subscriptionId?, String) = \"123456\")]"
               }
             },
             ];


### PR DESCRIPTION
When an edge detection is used (this includes both the 'edgedetection' and 'georref' with 'enters/exits' area) the event values available at output included only the previous values - i.e., the ones before the update message. This PR changes that so the available values are the 'after' ones.