### PR TITLE
Fixing http request node configuration panel

### DIFF
--- a/contrib-nodes/node-red-contrib-dojot/nodes/5-httprequest_out.html
+++ b/contrib-nodes/node-red-contrib-dojot/nodes/5-httprequest_out.html
@@ -30,6 +30,7 @@
         <input id="node-input-url" type="text" placeholder="http://">
     </div>
 
+    <!--
     <div class="form-row">
         <input type="checkbox" id="node-input-usetls" style="display: inline-block; width: auto; vertical-align: top;">
         <label for="node-input-usetls" style="width: auto" data-i18n="httpin.use-tls"></label>
@@ -52,6 +53,7 @@
             </div>
         </div>
     </div>
+    -->
     <div class="form-row">
       <label for="node-input-body"><i class="fa fa-envelope"></i> <span data-i18n="httpin.label.body"></span></label>
       <input type="text" id="node-input-body" placeholder="Message body">
@@ -139,12 +141,8 @@
             method:{value:"GET"},
             ret: {value:"txt"},
             body: {value:""},
-            url:{value:"",validate:function(v) { return (v.trim().length === 0) || (v.indexOf("://") === -1) || (v.trim().indexOf("http") === 0)} },
-            tls: {type:"tls-config",required: false}
-        },
-        credentials: {
-            user: {type:"text"},
-            password: {type: "password"}
+            url:{value:"",validate:function(v) { return (v.trim().length === 0) || (v.indexOf("://") === -1) || (v.trim().indexOf("http") === 0)} }
+            // tls: {type:"tls-config",required: false}
         },
         inputs:1,
         outputs:0,
@@ -159,38 +157,38 @@
             return this.name?"node_label_italic":"";
         },
         oneditprepare: function() {
-            $("#node-input-useAuth").change(function() {
-                if ($(this).is(":checked")) {
-                    $(".node-input-useAuth-row").show();
-                } else {
-                    $(".node-input-useAuth-row").hide();
-                    $('#node-input-user').val('');
-                    $('#node-input-password').val('');
-                }
-            });
-            if (this.credentials.user || this.credentials.has_password) {
-                $('#node-input-useAuth').prop('checked', true);
-            } else {
-                $('#node-input-useAuth').prop('checked', false);
-            }
-            $("#node-input-useAuth").change();
+            // $("#node-input-useAuth").change(function() {
+            //     if ($(this).is(":checked")) {
+            //         $(".node-input-useAuth-row").show();
+            //     } else {
+            //         $(".node-input-useAuth-row").hide();
+            //         $('#node-input-user').val('');
+            //         $('#node-input-password').val('');
+            //     }
+            // });
+            // if (this.credentials.user || this.credentials.has_password) {
+            //     $('#node-input-useAuth').prop('checked', true);
+            // } else {
+            //     $('#node-input-useAuth').prop('checked', false);
+            // }
+            // $("#node-input-useAuth").change();
 
-            function updateTLSOptions() {
-                if ($("#node-input-usetls").is(':checked')) {
-                    $("#node-row-tls").show();
-                } else {
-                    $("#node-row-tls").hide();
-                }
-            }
-            if (this.tls) {
-                $('#node-input-usetls').prop('checked', true);
-            } else {
-                $('#node-input-usetls').prop('checked', false);
-            }
-            updateTLSOptions();
-            $("#node-input-usetls").on("click",function() {
-                updateTLSOptions();
-            });
+            // function updateTLSOptions() {
+            //     if ($("#node-input-usetls").is(':checked')) {
+            //         $("#node-row-tls").show();
+            //     } else {
+            //         $("#node-row-tls").hide();
+            //     }
+            // }
+            // if (this.tls) {
+            //     $('#node-input-usetls').prop('checked', true);
+            // } else {
+            //     $('#node-input-usetls').prop('checked', false);
+            // }
+            // updateTLSOptions();
+            // $("#node-input-usetls").on("click",function() {
+            //     updateTLSOptions();
+            // });
             $("#node-input-ret").change(function() {
                 if ($("#node-input-ret").val() === "obj") {
                     $("#tip-json").show();
@@ -201,9 +199,9 @@
             $("#node-input-body").typedInput({default:'msg',types:['msg']});
         },
         oneditsave: function() {
-            if (!$("#node-input-usetls").is(':checked')) {
-                $("#node-input-tls").val("_ADD_");
-            }
+            // if (!$("#node-input-usetls").is(':checked')) {
+            //     $("#node-input-tls").val("_ADD_");
+            // }
         }
     });
 </script>


### PR DESCRIPTION
As the HTTP request node has a 'credentials' attribute, [node-red](https://nodered.org/docs/creating-nodes/credentials) retrieves them from the backend (by sending a GET request to /credentials/http-request-out/{NODE-ID}). Once we don't have this endpoint, this retrieval fails and the configuration panel doesn't show up in the GUI. 

All authentication elements were commented out from the node in order to correctly show the configuration panel. This feature (authentication) should be better analyzed and reimplemented into this node.

This fixes #7 