### PR TITLE
Fixing rule generation for node connected to multiple ones

### DIFF
--- a/orchestrator/translator.js
+++ b/orchestrator/translator.js
@@ -416,8 +416,9 @@ function extractFurtherNodes(objects, node, outputIx, request, requestList) {
     requestList.push(request);
   } else {
     for (let wire = 0; wire < node.wires[outputIx].length; wire++) {
+      let requestClone = cloneSimpleObject(request);
       let nextNode = objects[node.wires[outputIx][wire]];
-      let result = extractDataFromNode(objects, nextNode, request);
+      let result = extractDataFromNode(objects, nextNode, requestClone);
       requestList = requestList.concat(result);
     }
   }


### PR DESCRIPTION
This commit fixes a situation where multiple rules would be overriden if a particular node has more than one node connected to its output.