### PR TITLE
Fixing quotes in translator

### DIFF
--- a/orchestrator/resolver.js
+++ b/orchestrator/resolver.js
@@ -112,30 +112,20 @@ function resolveVariables(obj, text, specialVars, varTracking) {
   if (varTracking === undefined) {
     varTracking = {};
   }
-  // Adding quotes to moustache variables.
-  // Starting quotes
-  // Closing quotes
-  ret.data = ret.data.replace(/:( *(\n)*)*(?!\"|\'){{/g, ':"{{');
-  ret.data = ret.data.replace(/}}( *(\n)*)*(?!\"|\')(?=,|})/g, '}}"');
 
   if (typeof text === 'string') {
-    let beginTagIndex = ret.data.search('{{');
-    let endTagIndex = ret.data.search('}}');
-    while ((beginTagIndex >= 0) && (endTagIndex >= 0) && (beginTagIndex < endTagIndex)) {
-      // Remove '{{' from variable name
-      beginTagIndex += 2;
-      let tag = ret.data.slice(beginTagIndex, endTagIndex);
-      let expansion = expandVariable(obj, tag, specialVars, varTracking);
+    let tokens = /\"?\{{2}(.+?)\}{2}\"?/g.exec(ret.data);
+
+    while (tokens != null) {
+      let expansion = expandVariable(obj, tokens[1], specialVars, varTracking);
       if (expansion.result === 'ok') {
-        // Skip '{{' and '}}'
-        ret.data = ret.data.slice(0, beginTagIndex - 2) + expansion.data + ret.data.slice(endTagIndex + 2);
-        beginTagIndex = ret.data.search('{{');
-        endTagIndex = ret.data.search('}}');
+        ret.data = ret.data.replace(new RegExp('\{{2}(' + tokens[1] + ')\}{2}', 'g'), expansion.data);
       } else {
         ret.result = expansion.result;
         ret.data = expansion.data;
         break;
       }
+      tokens = /\"?\{{2}(.+?)\}{2}\"?/g.exec(ret.data);
     }
   }
   return ret;

--- a/orchestrator/resolver.js
+++ b/orchestrator/resolver.js
@@ -112,6 +112,11 @@ function resolveVariables(obj, text, specialVars, varTracking) {
   if (varTracking === undefined) {
     varTracking = {};
   }
+  // Adding quotes to moustache variables.
+  // Starting quotes
+  // Closing quotes
+  ret.data = ret.data.replace(/:( *(\n)*)*(?!\"|\'){{/g, ':"{{');
+  ret.data = ret.data.replace(/}}( *(\n)*)*(?!\"|\')(?=,|})/g, '}}"');
 
   if (typeof text === 'string') {
     let beginTagIndex = ret.data.search('{{');

--- a/orchestrator/translator.js
+++ b/orchestrator/translator.js
@@ -385,7 +385,7 @@ function transformToPerseoRequest(request) {
     case orchtypes.PerseoTypes.ActionType.UPDATE: {
       // Only attributes should be updated.
       let attributesVar = request.action.parameters.attributes;
-      varAccess = resolver.accessVariable(request.internalVariables, tools.tokenize(attributesVar, '.'));
+      varAccess = resolver.accessVariable(request.internalVariables, tools.tokenize(attributesVar, '.'), specialVars);
       if (varAccess.result !== 'ok') {
         throw "failure";
       }
@@ -401,6 +401,7 @@ function transformToPerseoRequest(request) {
       }
       perseoRule.action.parameters = request.action.parameters;
       perseoRule.action.parameters.attributes = [];
+      // This must be a json, so let's add some quotes.
       attributes = JSON.parse(resolvedVariables.data);
       for (let varName in attributes) {
         if (attributes.hasOwnProperty(varName)){

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
         "istanbul": "^0.4.5",
         "mocha": "^3.4.2",
         "should": "^8.4.0",
-        "sinon": "1.17.7",
+        "sinon": "~1.17.7",
         "supertest": "3.0.0"
     },
     "engines": {


### PR DESCRIPTION
This PR adds quotes whenever the user doesn't include them in template nodes. For instante, a user might write the following in a template node: 
```
{
"temp" : {{payload.t}}
}
```

which makes sense, once a float (or integer) doesn't require quotes, then the user won't add them here. Problem is that the actual rule will be created as 
```
{
"temp" : ${t}
}
```

which is an invalid JSON - mashup will be terminated because of this.

With this fix, the update action will be 
```
{
"temp" : "${t}"
}
```

This fixes dojot/mashup#21 and dojot/mashup#20