### PR TITLE
Adds support to mongodb replica sets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ node_modules
 public
 locales/zz-ZZ
 nodes/core/locales/zz-ZZ
+.idea/

--- a/orchestrator/config.js
+++ b/orchestrator/config.js
@@ -1,5 +1,6 @@
 /* jshint node: true */
 "use strict";
+
 var config = {};
 
 config.perseo_fe = {
@@ -12,7 +13,8 @@ config.orion = {
 }
 
 config.mongo = {
-  url: "mongodb://mongodb:27017/orchestrator"
+  url: "mongodb://mongodb:27017/orchestrator",
+  replicaSet: process.env.MONGO_REPLICA_SET
 }
 
 config.cygnus = {

--- a/orchestrator/server.js
+++ b/orchestrator/server.js
@@ -338,7 +338,11 @@ function init() {
     connectTimeoutMS: 2500,
     reconnectTries: 100,
     reconnectInterval: 2500,
-    autoReconnect: true
+    autoReconnect: true,
+  }
+
+  if (config.mongo.replicaSet) {
+    opt.replicaSet = config.mongo.replicaSet;
   }
 
   console.log('Starting orchestrator service...');


### PR DESCRIPTION
This push request adds support to MongoDB Replica Sets for the mashup component.

The ReplicaSet that will be used can be passed to the docker container via environment variable.

Connects to dojot/dojot#188